### PR TITLE
src: large restructuring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,6 +393,7 @@ dependencies = [
 name = "vault"
 version = "0.1.0"
 dependencies = [
+ "any_derive",
  "datadriven",
  "fs_extra",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 authors = ["Rohan Yadav <rohany@cs.stanford.edu>"]
 edition = "2018"
 
+[workspace]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+any_derive = { path = "src/any_derive", version = "0.1.0" }
 datadriven = "0.4.0"
 fs_extra = "1.2.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/any_derive/Cargo.toml
+++ b/src/any_derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "any_derive"
+version = "0.1.0"
+authors = ["Rohan Yadav <rohany@cs.stanford.edu>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/src/any_derive/src/lib.rs
+++ b/src/any_derive/src/lib.rs
@@ -1,0 +1,22 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use std::any::Any;
+use syn;
+
+#[proc_macro_derive(AsAny)]
+/// as_any_macro_derive derives an implementation of the vault::util::AsAny
+/// trait on a target struct using the derive(AsAny) field.
+pub fn as_any_macro_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree.
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+    let name = &ast.ident;
+    let gen = quote! {
+        impl crate::vault::util::AsAny for #name {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+        }
+    };
+    gen.into()
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ use structopt::StructOpt;
 ///   * vault register <experiment_name>
 ///   * vault store <experiment_name> <instance_directory>
 ///   * vault add-meta <instance_directory> <key> <value>
+///   * vault list-meta <instance_directory>
 ///   * vault get-latest <experiment_mame>
 ///   * vault query ...
 pub enum Commands {
@@ -22,6 +23,9 @@ pub enum Commands {
         directory: String,
         key: String,
         value: String,
+    },
+    ListMeta {
+        directory: String,
     },
     GetLatest {
         experiment: String,

--- a/test/testdata/vault/commands/add-meta
+++ b/test/testdata/vault/commands/add-meta
@@ -7,4 +7,17 @@ add-meta instance=i key=k value=v
 add-meta instance=i key=k2 value=v2
 ----
 
-# TODO (rohany): We need a "list-meta" command to verify this.
+list-meta instance=i
+----
+key: k, value: v
+key: k2, value: v2
+
+# Adding meta for an existing key should overwrite it.
+
+add-meta instance=i key=k value=overwrite
+----
+
+list-meta instance=i
+----
+key: k, value: overwrite
+key: k2, value: v2

--- a/test/testdata/vault/commands/get-latest
+++ b/test/testdata/vault/commands/get-latest
@@ -15,8 +15,23 @@ get-latest experiment=exp
 ----
 No stored instances!
 
-# Create a new instance.
+# Create a new instance and store it.
 new-instance name=i
 ----
 
-# TODO (rohany): Need a store instance command now.
+store-instance experiment=exp instance=i
+----
+
+get-latest experiment=exp
+----
+i
+
+new-instance name=i2
+----
+
+store-instance experiment=exp instance=i2
+----
+
+get-latest experiment=exp
+----
+i2


### PR DESCRIPTION
* Adjust the return type of a vault command to be castable concrete types
* Add a procedural macro crate to generate implementations for a trait
* Move more tests into the data driven framework